### PR TITLE
fix: corrigir ID do Google Analytics para conta correta

### DIFF
--- a/curso.html
+++ b/curso.html
@@ -11,12 +11,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/curso.html">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <meta name="description" content="Cursos de pós-operatório, drenagem linfática e taping em Jaguariúna com Francielle Alves, referência na região de Campinas. Formação prática e certificação profissional.">
     <meta name="robots" content="index, follow">

--- a/cursos-vip.html
+++ b/cursos-vip.html
@@ -22,12 +22,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/cursos-vip.html">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <link rel="stylesheet" href="css/modern-style.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0" crossorigin="anonymous">

--- a/ebook-detox-novo.html
+++ b/ebook-detox-novo.html
@@ -24,12 +24,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/ebook-detox-novo.html">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <link rel="stylesheet" href="css/modern-style.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Montserrat+Alternates:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/ebook-detox.html
+++ b/ebook-detox.html
@@ -21,12 +21,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/ebook-detox.html">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     
     <!-- Fontes e estilos -->    

--- a/index.html
+++ b/index.html
@@ -24,12 +24,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <link rel="stylesheet" href="css/modern-style.css">
     <link rel="stylesheet" href="css/BeerSlider.css">

--- a/slimshape.html
+++ b/slimshape.html
@@ -24,12 +24,12 @@
     <link rel="apple-touch-icon" sizes="180x180" href="assets/icon/apple-touch-icon.png">
     <link rel="canonical" href="https://franciellealves.com/slimshape.html">
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <link rel="stylesheet" href="css/modern-style.css">
     <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;500;600;700&family=Montserrat+Alternates:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/taping.html
+++ b/taping.html
@@ -33,13 +33,12 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css" integrity="sha384-/rJKQnzOkEo+daG0jMjU1IwwY9unxt1NBw3Ef2fmOJ3PW/TfAg2KXVoWwMZQZtw9" crossorigin="anonymous" />
     
     <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-V3M0E5KL9R"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-B60XK48FK1"></script>
     <script>
       window.dataLayer = window.dataLayer || [];
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
-
-      gtag('config', 'G-V3M0E5KL9R');
+      gtag('config', 'G-B60XK48FK1');
     </script>
     <!-- Schema Markup para Course -->
     <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Substitui o ID de rastreamento incorreto `G-V3M0E5KL9R` pelo ID correto `G-B60XK48FK1` em todas as 7 páginas
- O ID anterior não estava vinculado à conta `franciellealvessite@gmail.com`, portanto nenhum dado era coletado
- Corrigida também uma linha em branco desnecessária no script do `taping.html`

## Arquivos alterados
- `index.html`
- `taping.html`
- `slimshape.html`
- `cursos-vip.html`
- `curso.html`
- `ebook-detox.html`
- `ebook-detox-novo.html`

## Test plan
- [ ] Fazer merge e aguardar deploy no GitHub Pages
- [ ] Acessar o site e verificar no Google Analytics > Relatórios em tempo real se a visita aparece
- [ ] Clicar em "Test installation" no painel do Google Analytics para confirmar